### PR TITLE
add older dpi scaling options

### DIFF
--- a/progmgr/progmgr.exe.manifest
+++ b/progmgr/progmgr.exe.manifest
@@ -2,7 +2,8 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 	<asmv3:application>
 		<asmv3:windowsSettings>
-			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<dependency>


### PR DESCRIPTION
PerMonitorV2 is good but it only works on win10+
for older versions you need a few more definitions in the manifest:
https://building.enlyze.com/posts/writing-win32-apps-like-its-2020-part-3/